### PR TITLE
Feat: Show library bookmark badge in search results

### DIFF
--- a/app/src/main/java/com/emptycastle/novery/data/local/dao/LibraryDao.kt
+++ b/app/src/main/java/com/emptycastle/novery/data/local/dao/LibraryDao.kt
@@ -16,6 +16,9 @@ interface LibraryDao {
     @Query("SELECT * FROM library ORDER BY lastReadAt DESC, addedAt DESC")
     fun getAllFlow(): Flow<List<LibraryEntity>>
 
+    @Query("SELECT url FROM library")
+    fun observeLibraryUrls(): Flow<List<String>>
+
     @Query("SELECT * FROM library ORDER BY lastReadAt DESC, addedAt DESC")
     suspend fun getAll(): List<LibraryEntity>
 

--- a/app/src/main/java/com/emptycastle/novery/data/repository/LibraryRepository.kt
+++ b/app/src/main/java/com/emptycastle/novery/data/repository/LibraryRepository.kt
@@ -13,6 +13,7 @@ import com.emptycastle.novery.domain.model.ReadingStatus
 import com.emptycastle.novery.provider.MainProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
@@ -72,6 +73,12 @@ class LibraryRepository(
         return libraryDao.getAllFlow().map { entities ->
             entities.map { entity -> entity.toLibraryItem() }
         }
+    }
+
+    fun observeLibraryUrls(): Flow<Set<String>> {
+        return libraryDao.observeLibraryUrls()
+            .map { urls -> urls.toSet() }
+            .distinctUntilChanged()
     }
 
     fun observeIsFavorite(url: String): Flow<Boolean> {

--- a/app/src/main/java/com/emptycastle/novery/ui/components/NovelCard.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/components/NovelCard.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoStories
+import androidx.compose.material.icons.rounded.Bookmark
 import androidx.compose.material.icons.rounded.MenuBook
 import androidx.compose.material.icons.rounded.NewReleases
 import androidx.compose.material3.Card
@@ -83,6 +84,7 @@ import coil.compose.SubcomposeAsyncImageContent
 import com.emptycastle.novery.domain.model.Novel
 import com.emptycastle.novery.domain.model.ReadingStatus
 import com.emptycastle.novery.domain.model.UiDensity
+import com.emptycastle.novery.ui.screens.details.util.DetailsColors
 import com.emptycastle.novery.ui.theme.StatusCompleted
 import com.emptycastle.novery.ui.theme.StatusDROPPED
 import com.emptycastle.novery.ui.theme.StatusOnHold
@@ -139,12 +141,14 @@ fun NovelCard(
     readingStatus: ReadingStatus? = null,
     lastReadChapter: String? = null,
     showApiName: Boolean = false,
-    isSelected: Boolean = false
+    isSelected: Boolean = false,
+    isInLibrary: Boolean = false
 ) {
     val semanticsLabel = buildString {
         append(novel.name)
         readingStatus?.let { append(", ${it.displayName()}") }
         if (newChapterCount > 0) append(", $newChapterCount new chapters")
+        if (isInLibrary) append(", in library")
         lastReadChapter?.let { append(", last read: $it") }
     }
 
@@ -161,7 +165,8 @@ fun NovelCard(
             readingStatus = readingStatus,
             lastReadChapter = lastReadChapter,
             showApiName = showApiName,
-            isSelected = isSelected
+            isSelected = isSelected,
+            isInLibrary = isInLibrary
         )
         else -> CompactNovelCard(
             novel = novel,
@@ -176,7 +181,8 @@ fun NovelCard(
             lastReadChapter = lastReadChapter,
             showApiName = showApiName,
             isCompact = density == UiDensity.COMPACT,
-            isSelected = isSelected
+            isSelected = isSelected,
+            isInLibrary = isInLibrary
         )
     }
 }
@@ -196,7 +202,8 @@ private fun ComfortableNovelCard(
     readingStatus: ReadingStatus?,
     lastReadChapter: String?,
     showApiName: Boolean,
-    isSelected: Boolean
+    isSelected: Boolean,
+    isInLibrary: Boolean
 ) {
     val haptic = LocalHapticFeedback.current
     val interactionSource = remember { MutableInteractionSource() }
@@ -270,6 +277,7 @@ private fun ComfortableNovelCard(
                 BadgeRow(
                     readingStatus = readingStatus,
                     newChapterCount = newChapterCount,
+                    isInLibrary = isInLibrary,
                     compactMode = false,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -328,7 +336,8 @@ private fun CompactNovelCard(
     lastReadChapter: String?,
     showApiName: Boolean,
     isCompact: Boolean,
-    isSelected: Boolean
+    isSelected: Boolean,
+    isInLibrary: Boolean
 ) {
     val haptic = LocalHapticFeedback.current
     val interactionSource = remember { MutableInteractionSource() }
@@ -388,6 +397,7 @@ private fun CompactNovelCard(
             BadgeRow(
                 readingStatus = readingStatus,
                 newChapterCount = newChapterCount,
+                isInLibrary = isInLibrary,
                 compactMode = isCompact,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -584,6 +594,7 @@ private fun CinematicOverlay(modifier: Modifier = Modifier) {
 private fun BadgeRow(
     readingStatus: ReadingStatus?,
     newChapterCount: Int,
+    isInLibrary: Boolean,
     compactMode: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -607,17 +618,59 @@ private fun BadgeRow(
 
         Spacer(Modifier.weight(1f))
 
-        AnimatedVisibility(
-            visible = newChapterCount > 0,
-            enter = fadeIn() + scaleIn(
-                initialScale = 0.5f,
-                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-            ),
-            exit = fadeOut() + scaleOut()
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.Top
         ) {
-            NewChaptersBadge(
-                count = newChapterCount,
-                compactMode = compactMode
+            AnimatedVisibility(
+                visible = isInLibrary,
+                enter = fadeIn() + scaleIn(
+                    initialScale = 0.5f,
+                    animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                ),
+                exit = fadeOut() + scaleOut()
+            ) {
+                LibraryBookmarkBadge(compactMode = compactMode)
+            }
+
+            AnimatedVisibility(
+                visible = newChapterCount > 0,
+                enter = fadeIn() + scaleIn(
+                    initialScale = 0.5f,
+                    animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                ),
+                exit = fadeOut() + scaleOut()
+            ) {
+                NewChaptersBadge(
+                    count = newChapterCount,
+                    compactMode = compactMode
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryBookmarkBadge(
+    modifier: Modifier = Modifier,
+    compactMode: Boolean = false
+) {
+    // Reuse the details cover treatment so "in library" reads consistently across screens.
+    Surface(
+        modifier = modifier.size(if (compactMode) 22.dp else 24.dp),
+        shape = CircleShape,
+        color = DetailsColors.Pink.copy(alpha = 0.9f),
+        shadowElevation = NovelCardTokens.Elevation.Badge
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Bookmark,
+                contentDescription = "In library",
+                modifier = Modifier.size(if (compactMode) 12.dp else 14.dp),
+                tint = Color.White
             )
         }
     }

--- a/app/src/main/java/com/emptycastle/novery/ui/components/NovelListItem.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/components/NovelListItem.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.MenuBook
 import androidx.compose.material.icons.rounded.AutoStories
+import androidx.compose.material.icons.rounded.Bookmark
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.NewReleases
 import androidx.compose.material3.Card
@@ -78,6 +79,7 @@ import coil.compose.SubcomposeAsyncImageContent
 import com.emptycastle.novery.domain.model.Novel
 import com.emptycastle.novery.domain.model.ReadingStatus
 import com.emptycastle.novery.domain.model.UiDensity
+import com.emptycastle.novery.ui.screens.details.util.DetailsColors
 import com.emptycastle.novery.ui.theme.StatusCompleted
 import com.emptycastle.novery.ui.theme.StatusDROPPED
 import com.emptycastle.novery.ui.theme.StatusOnHold
@@ -145,7 +147,8 @@ fun NovelListItem(
     readingStatus: ReadingStatus? = null,
     lastReadChapter: String? = null,
     showApiName: Boolean = false,
-    isSelected: Boolean = false
+    isSelected: Boolean = false,
+    isInLibrary: Boolean = false
 ) {
     val haptic = LocalHapticFeedback.current
     val interactionSource = remember { MutableInteractionSource() }
@@ -189,6 +192,7 @@ fun NovelListItem(
         append(novel.name)
         readingStatus?.let { append(", ${it.displayName()}") }
         if (newChapterCount > 0) append(", $newChapterCount new chapters")
+        if (isInLibrary) append(", in library")
         lastReadChapter?.let { append(", last read: $it") }
     }
 
@@ -254,10 +258,10 @@ fun NovelListItem(
                 // Subtle vignette for badge contrast
                 ListItemVignette(modifier = Modifier.fillMaxSize())
 
-                // New chapters badge on image
+                // Library and new chapter badges on image
                 // FIX: Use fully qualified name to avoid RowScope/BoxScope conflict
                 androidx.compose.animation.AnimatedVisibility(
-                    visible = newChapterCount > 0,
+                    visible = isInLibrary || newChapterCount > 0,
                     modifier = Modifier
                         .align(Alignment.TopEnd)
                         .padding(ListItemTokens.Padding.Badge),
@@ -267,10 +271,21 @@ fun NovelListItem(
                     ),
                     exit = fadeOut() + scaleOut()
                 ) {
-                    ListNewChaptersBadge(
-                        count = newChapterCount,
-                        compact = density == UiDensity.COMPACT
-                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        if (isInLibrary) {
+                            ListLibraryBookmarkBadge(compact = density == UiDensity.COMPACT)
+                        }
+
+                        if (newChapterCount > 0) {
+                            ListNewChaptersBadge(
+                                count = newChapterCount,
+                                compact = density == UiDensity.COMPACT
+                            )
+                        }
+                    }
                 }
 
                 // Status indicator at bottom-left of image
@@ -600,6 +615,32 @@ private fun ListStatusDot(
 // ══════════════════════════════════════════════════════════════════════════════
 // New Chapters Badge
 // ══════════════════════════════════════════════════════════════════════════════
+
+@Composable
+private fun ListLibraryBookmarkBadge(
+    modifier: Modifier = Modifier,
+    compact: Boolean = false
+) {
+    // Reuse the details cover treatment so "in library" reads consistently across screens.
+    Surface(
+        modifier = modifier.size(if (compact) 20.dp else 22.dp),
+        shape = CircleShape,
+        color = DetailsColors.Pink.copy(alpha = 0.9f),
+        shadowElevation = ListItemTokens.Elevation.Badge
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Bookmark,
+                contentDescription = "In library",
+                modifier = Modifier.size(if (compact) 11.dp else 13.dp),
+                tint = Color.White
+            )
+        }
+    }
+}
 
 @Composable
 private fun ListNewChaptersBadge(

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseTab.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseTab.kt
@@ -340,6 +340,7 @@ fun BrowseTab(
                         ExpandedSearchResults(
                             providerName = expandedProvider,
                             novels = novels,
+                            libraryNovelUrls = uiState.libraryNovelUrls,
                             isLoading = providerState is ProviderSearchState.Loading,
                             error = (providerState as? ProviderSearchState.Error)?.message,
                             gridColumns = gridColumns,
@@ -360,6 +361,7 @@ fun BrowseTab(
                             providerStates = uiState.filteredProviderStates,
                             providers = uiState.providers,
                             favoriteProviders = uiState.favoriteProviders,
+                            libraryNovelUrls = uiState.libraryNovelUrls,
                             resultsPerProvider = resultsPerProvider,
                             filters = uiState.filters,
                             isSearching = uiState.isSearching,
@@ -734,6 +736,7 @@ private fun SearchResultsContent(
     providerStates: Map<String, ProviderSearchState>,
     providers: List<MainProvider>,
     favoriteProviders: Set<String>,
+    libraryNovelUrls: Set<String>,
     resultsPerProvider: Int,
     filters: SearchFilters,
     isSearching: Boolean,
@@ -808,6 +811,7 @@ private fun SearchResultsContent(
                                 ProviderSearchResultsSection(
                                     providerName = providerName,
                                     novels = state.novels,
+                                    libraryNovelUrls = libraryNovelUrls,
                                     maxResults = resultsPerProvider,
                                     onNovelClick = onNovelClick,
                                     onNovelLongClick = onNovelLongClick,
@@ -1209,6 +1213,7 @@ private fun ProviderErrorResultsSection(
 private fun ProviderSearchResultsSection(
     providerName: String,
     novels: List<Novel>,
+    libraryNovelUrls: Set<String>,
     maxResults: Int,
     onNovelClick: (Novel) -> Unit,
     onNovelLongClick: (Novel) -> Unit,
@@ -1301,6 +1306,7 @@ private fun ProviderSearchResultsSection(
                             onClick = { onNovelClick(novel) },
                             onLongClick = { onNovelLongClick(novel) },
                             density = appSettings.uiDensity,
+                            isInLibrary = novel.url in libraryNovelUrls,
                             modifier = Modifier.width(110.dp)
                         )
                     }
@@ -1324,6 +1330,7 @@ private fun ProviderSearchResultsSection(
                             onClick = { onNovelClick(novel) },
                             onLongClick = { onNovelLongClick(novel) },
                             density = appSettings.uiDensity,
+                            isInLibrary = novel.url in libraryNovelUrls,
                             modifier = Modifier.padding(horizontal = dimensions.gridPadding)
                         )
                     }
@@ -1403,6 +1410,7 @@ private fun ViewMoreCard(
 private fun ExpandedSearchResults(
     providerName: String,
     novels: List<Novel>,
+    libraryNovelUrls: Set<String>,
     isLoading: Boolean,
     error: String?,
     gridColumns: Int,
@@ -1608,7 +1616,8 @@ private fun ExpandedSearchResults(
                             onClick = { onNovelClick(novel) },
                             onLongClick = { onNovelLongClick(novel) },
                             showApiName = false,
-                            density = appSettings.uiDensity
+                            density = appSettings.uiDensity,
+                            isInLibrary = novel.url in libraryNovelUrls
                         )
                     }
                 }

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseUiState.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseUiState.kt
@@ -37,6 +37,7 @@ data class BrowseUiState(
     val isLoadingProviders: Boolean = true,
     val providerError: String? = null,
     val favoriteProviders: Set<String> = emptySet(),
+    val libraryNovelUrls: Set<String> = emptySet(),
 
     // Search state
     val searchQuery: String = "",

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseViewModel.kt
@@ -21,6 +21,7 @@ class BrowseViewModel : ViewModel() {
 
     private val novelRepository = RepositoryProvider.getNovelRepository()
     private val preferencesManager = RepositoryProvider.getPreferencesManager()
+    private val libraryRepository = RepositoryProvider.getLibraryRepository()
 
     private val _uiState = MutableStateFlow(BrowseUiState())
     val uiState: StateFlow<BrowseUiState> = _uiState.asStateFlow()
@@ -65,6 +66,19 @@ class BrowseViewModel : ViewModel() {
                 preferencesManager.favoriteProviders.collect { favorites ->
                     _uiState.update { it.copy(favoriteProviders = favorites) }
                     refreshProviders()
+                }
+            }
+            launch {
+                // Keep source-specific library URLs in memory so search cards can mark only the
+                // saved result from the same source without per-card database queries.
+                libraryRepository.observeLibrary().collect { libraryItems ->
+                    _uiState.update {
+                        it.copy(
+                            libraryNovelUrls = libraryItems.mapTo(mutableSetOf()) { item ->
+                                item.novel.url
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseViewModel.kt
@@ -71,13 +71,9 @@ class BrowseViewModel : ViewModel() {
             launch {
                 // Keep source-specific library URLs in memory so search cards can mark only the
                 // saved result from the same source without per-card database queries.
-                libraryRepository.observeLibrary().collect { libraryItems ->
+                libraryRepository.observeLibraryUrls().collect { libraryNovelUrls ->
                     _uiState.update {
-                        it.copy(
-                            libraryNovelUrls = libraryItems.mapTo(mutableSetOf()) { item ->
-                                item.novel.url
-                            }
-                        )
+                        it.copy(libraryNovelUrls = libraryNovelUrls)
                     }
                 }
             }


### PR DESCRIPTION
Added a small but useful visual improvement to global search results.

When a novel from the search results is already saved in the user’s library, the app now shows a bookmark badge on that result. It makes it much easier to tell which result is already in the library, especially when the same title appears from multiple sources.

## How It Works

The badge matches the novel URL, so it only appears for the exact saved source.

For example, if the user has saved `Shadow Slave` from Source A, then a global search for `Shadow` may show results from Source A, Source B, and Source C. Only the Source A result will show the bookmark badge.

The badge uses the same visual style as the bookmark indicator on the novel details cover, so it feels consistent with the rest of the app.

  ## Performance

The Browse screen now only observes saved library URLs, rather than rebuilding full library items. It keeps the search UI lightweight and avoids unnecessary updates when unrelated library data changes, such as reading progress.

## Testing
 - Installed and tested the app on a physical Android device.
 - Verified the app starts without error-level logs.


### Before
<img width="720" height="1600" alt="Screenshot_2026-05-01-07-46-00-373_com emptycastle novery" src="https://github.com/user-attachments/assets/113f0aa1-c1e8-47d5-ad88-539bc51f90b1" />

### After
<img width="720" height="1600" alt="Screenshot_20260501-074654" src="https://github.com/user-attachments/assets/ed95292c-34bb-4cfb-a16b-ca09d0de3238" />
