### PR TITLE
feat: added duplicate book detection

### DIFF
--- a/app/src/main/java/com/emptycastle/novery/data/repository/LibraryRepository.kt
+++ b/app/src/main/java/com/emptycastle/novery/data/repository/LibraryRepository.kt
@@ -175,6 +175,20 @@ class LibraryRepository(
         }
     }
 
+    suspend fun findDuplicateCandidates(novel: Novel): List<LibraryItem> = withContext(Dispatchers.IO) {
+        val targetTitle = normalizeDuplicateTitle(novel.name)
+        if (targetTitle.isBlank()) return@withContext emptyList()
+
+        // Compare normalized titles so source labels or bracketed suffixes don't hide likely duplicates.
+        libraryDao.getAll()
+            .asSequence()
+            .filter { it.url != novel.url }
+            .filter { normalizeDuplicateTitle(it.name) == targetTitle }
+            .take(MAX_DUPLICATE_CANDIDATES)
+            .map { it.toLibraryItem() }
+            .toList()
+    }
+
     // ================================================================
     // MODIFY LIBRARY
     // ================================================================
@@ -486,6 +500,22 @@ class LibraryRepository(
             hasNewChapters = hasNewChapters,
             lastCheckedAt = lastCheckedAt
         )
+    }
+
+    private fun normalizeDuplicateTitle(title: String): String {
+        return title
+            .lowercase()
+            .replace(BRACKETED_TEXT_REGEX, " ")
+            .replace(NON_TITLE_CHARACTER_REGEX, " ")
+            .trim()
+            .replace(WHITESPACE_REGEX, " ")
+    }
+
+    companion object {
+        private const val MAX_DUPLICATE_CANDIDATES = 5
+        private val BRACKETED_TEXT_REGEX = Regex("""\([^)]*\)|\[[^]]*]""")
+        private val NON_TITLE_CHARACTER_REGEX = Regex("""[^a-z0-9]+""")
+        private val WHITESPACE_REGEX = Regex("""\s+""")
     }
 
     // ================================================================

--- a/app/src/main/java/com/emptycastle/novery/ui/components/DuplicateLibraryDialog.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/components/DuplicateLibraryDialog.kt
@@ -1,0 +1,193 @@
+package com.emptycastle.novery.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BookmarkAdded
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.emptycastle.novery.data.repository.LibraryItem
+import com.emptycastle.novery.domain.model.Novel
+
+@Composable
+fun DuplicateLibraryDialog(
+    target: Novel,
+    duplicates: List<LibraryItem>,
+    onViewExisting: (LibraryItem) -> Unit,
+    onAddAnyway: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val primaryDuplicate = duplicates.firstOrNull()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = MaterialTheme.colorScheme.surface,
+        tonalElevation = 0.dp,
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.BookmarkAdded,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+
+                Text(
+                    text = "Possible duplicates",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = target.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = "You already have an entry in your library with a similar name. Check the saved copy before adding this source too.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            primaryDuplicate?.let { duplicate ->
+                DuplicateLibraryItemCard(
+                    duplicate = duplicate,
+                    onClick = { onViewExisting(duplicate) }
+                )
+            }
+
+            Button(
+                onClick = onAddAnyway,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Add anyway")
+            }
+
+            OutlinedButton(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Cancel")
+            }
+        }
+    }
+}
+
+@Composable
+private fun DuplicateLibraryItemCard(
+    duplicate: LibraryItem,
+    onClick: () -> Unit
+) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Card(
+                modifier = Modifier.size(width = 56.dp, height = 78.dp),
+                shape = RoundedCornerShape(10.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                )
+            ) {
+                if (!duplicate.novel.posterUrl.isNullOrBlank()) {
+                    AsyncImage(
+                        model = duplicate.novel.posterUrl,
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.BookmarkAdded,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = duplicate.novel.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = duplicate.novel.apiName.ifBlank { "Unknown source" },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = "Tap to open saved entry",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/details/DetailsScreen.kt
@@ -55,6 +55,7 @@ import com.emptycastle.novery.epub.EpubExportOptions
 import com.emptycastle.novery.recommendation.TagNormalizer
 import com.emptycastle.novery.service.DownloadServiceManager
 import com.emptycastle.novery.service.DownloadState
+import com.emptycastle.novery.ui.components.DuplicateLibraryDialog
 import com.emptycastle.novery.ui.components.FullScreenLoading
 import com.emptycastle.novery.ui.screens.details.components.ActionButtonsRow
 import com.emptycastle.novery.ui.screens.details.components.ChapterItem
@@ -112,6 +113,19 @@ fun DetailsScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
+
+    uiState.duplicateWarning?.let { warning ->
+        DuplicateLibraryDialog(
+            target = warning.target,
+            duplicates = warning.duplicates,
+            onViewExisting = { duplicate ->
+                viewModel.dismissDuplicateWarning()
+                onNovelClick(duplicate.novel.url, duplicate.novel.apiName)
+            },
+            onAddAnyway = { viewModel.addDuplicateAnyway() },
+            onDismiss = { viewModel.dismissDuplicateWarning() }
+        )
+    }
 
     val isDownloadingThisNovel = downloadState.isActive && downloadState.novelUrl == novelUrl
     val filteredChapters = uiState.filteredChapters

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/details/DetailsUiState.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/details/DetailsUiState.kt
@@ -5,6 +5,7 @@ import com.emptycastle.novery.domain.model.Novel
 import com.emptycastle.novery.domain.model.NovelDetails
 import com.emptycastle.novery.domain.model.ReadingStatus
 import com.emptycastle.novery.domain.model.UserReview
+import com.emptycastle.novery.ui.screens.home.shared.DuplicateLibraryWarning
 
 /**
  * Chapter filter options
@@ -40,6 +41,7 @@ data class DetailsUiState(
     val isFavorite: Boolean = false,
     val isInLibrary: Boolean = false,
     val readingStatus: ReadingStatus = ReadingStatus.READING,
+    val duplicateWarning: DuplicateLibraryWarning? = null,
 
     // Reading position
     val hasStartedReading: Boolean = false,

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/details/DetailsViewModel.kt
@@ -15,6 +15,7 @@ import com.emptycastle.novery.epub.EpubExporter
 import com.emptycastle.novery.provider.MainProvider
 import com.emptycastle.novery.service.DownloadServiceManager
 import com.emptycastle.novery.service.DownloadState
+import com.emptycastle.novery.ui.screens.home.shared.DuplicateLibraryWarning
 import com.emptycastle.novery.util.ImageUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -322,14 +323,33 @@ class DetailsViewModel : ViewModel() {
                 libraryRepository.removeFromLibrary(details.url)
                 _uiState.update { it.copy(isFavorite = false) }
             } else {
-                libraryRepository.addToLibraryWithDetails(
-                    novel = novel,
-                    details = details,
-                    status = _uiState.value.readingStatus
-                )
-                _uiState.update { it.copy(isFavorite = true) }
+                // Direct details adds should follow the same duplicate warning flow as browse results.
+                val duplicates = libraryRepository.findDuplicateCandidates(novel)
+                if (duplicates.isNotEmpty()) {
+                    _uiState.update {
+                        it.copy(duplicateWarning = DuplicateLibraryWarning(novel, duplicates))
+                    }
+                    return@launch
+                }
+
+                addToLibraryWithDetails(novel, details)
             }
         }
+    }
+
+    fun addDuplicateAnyway() {
+        val details = _uiState.value.novelDetails ?: return
+        val provider = currentProvider ?: return
+        val novel = createNovel(details, provider)
+
+        viewModelScope.launch {
+            addToLibraryWithDetails(novel, details)
+            dismissDuplicateWarning()
+        }
+    }
+
+    fun dismissDuplicateWarning() {
+        _uiState.update { it.copy(duplicateWarning = null) }
     }
 
     fun updateReadingStatus(status: ReadingStatus) {
@@ -897,14 +917,21 @@ class DetailsViewModel : ViewModel() {
     ) {
         if (!_uiState.value.isFavorite) {
             viewModelScope.launch {
-                libraryRepository.addToLibraryWithDetails(
-                    novel = novel,
-                    details = details,
-                    status = _uiState.value.readingStatus
-                )
-                _uiState.update { it.copy(isFavorite = true) }
+                addToLibraryWithDetails(novel, details)
             }
         }
+    }
+
+    private suspend fun addToLibraryWithDetails(
+        novel: Novel,
+        details: com.emptycastle.novery.domain.model.NovelDetails
+    ) {
+        libraryRepository.addToLibraryWithDetails(
+            novel = novel,
+            details = details,
+            status = _uiState.value.readingStatus
+        )
+        _uiState.update { it.copy(isFavorite = true, duplicateWarning = null) }
     }
 
     private fun startBackgroundDownload(context: Context, chapters: List<Chapter>) {

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/shared/ActionSheetManager.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/shared/ActionSheetManager.kt
@@ -25,7 +25,13 @@ data class ActionSheetState(
     val isVisible: Boolean = false,
     val data: NovelActionSheetData? = null,
     val source: ActionSheetSource? = null,
-    val historyItem: HistoryItem? = null
+    val historyItem: HistoryItem? = null,
+    val duplicateWarning: DuplicateLibraryWarning? = null
+)
+
+data class DuplicateLibraryWarning(
+    val target: Novel,
+    val duplicates: List<LibraryItem>
 )
 
 /**
@@ -191,14 +197,33 @@ class ActionSheetManager {
     }
 
     // Library actions
-    suspend fun addToLibrary(novel: Novel): Boolean {
+    suspend fun addToLibrary(novel: Novel, allowDuplicate: Boolean = false): Boolean {
         return try {
+            if (!allowDuplicate) {
+                // The bottom sheet lets the user decide before adding the same title from another source.
+                val duplicates = libraryRepository.findDuplicateCandidates(novel)
+                if (duplicates.isNotEmpty()) {
+                    _state.update { it.copy(duplicateWarning = DuplicateLibraryWarning(novel, duplicates)) }
+                    return false
+                }
+            }
+
             libraryRepository.addToLibrary(novel)
+            dismissDuplicateWarning()
             refreshLibraryStatus()
             true
         } catch (e: Exception) {
             false
         }
+    }
+
+    fun dismissDuplicateWarning() {
+        _state.update { it.copy(duplicateWarning = null) }
+    }
+
+    suspend fun addDuplicateAnyway(): Boolean {
+        val target = _state.value.duplicateWarning?.target ?: return false
+        return addToLibrary(target, allowDuplicate = true)
     }
 
     suspend fun removeFromLibrary(novelUrl: String): Boolean {

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseTab.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseTab.kt
@@ -122,6 +122,7 @@ import com.emptycastle.novery.data.remote.CloudflareManager
 import com.emptycastle.novery.domain.model.AppSettings
 import com.emptycastle.novery.domain.model.Novel
 import com.emptycastle.novery.provider.MainProvider
+import com.emptycastle.novery.ui.components.DuplicateLibraryDialog
 import com.emptycastle.novery.ui.components.NovelActionSheet
 import com.emptycastle.novery.ui.components.NovelCard
 import com.emptycastle.novery.ui.components.NoverySearchBar
@@ -246,6 +247,19 @@ fun BrowseTab(
             } else null,
             onStatusChange = { status -> viewModel.updateReadingStatus(status) },
             onRemoveFromHistory = null
+        )
+    }
+
+    actionSheetState.duplicateWarning?.let { warning ->
+        DuplicateLibraryDialog(
+            target = warning.target,
+            duplicates = warning.duplicates,
+            onViewExisting = { duplicate ->
+                viewModel.dismissDuplicateWarning()
+                onNavigateToDetails(duplicate.novel.url, duplicate.novel.apiName)
+            },
+            onAddAnyway = { viewModel.addDuplicateAnyway() },
+            onDismiss = { viewModel.dismissDuplicateWarning() }
         )
     }
 

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseViewModel.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/BrowseViewModel.kt
@@ -321,6 +321,14 @@ class BrowseViewModel : ViewModel() {
         viewModelScope.launch { actionSheetManager.addToLibrary(novel) }
     }
 
+    fun addDuplicateAnyway() {
+        viewModelScope.launch { actionSheetManager.addDuplicateAnyway() }
+    }
+
+    fun dismissDuplicateWarning() {
+        actionSheetManager.dismissDuplicateWarning()
+    }
+
     fun removeFromLibrary(novelUrl: String) {
         viewModelScope.launch { actionSheetManager.removeFromLibrary(novelUrl) }
     }

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/ProviderBrowseScreen.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/ProviderBrowseScreen.kt
@@ -127,6 +127,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.emptycastle.novery.domain.model.AppSettings
 import com.emptycastle.novery.domain.model.Novel
 import com.emptycastle.novery.provider.MainProvider
+import com.emptycastle.novery.ui.components.DuplicateLibraryDialog
 import com.emptycastle.novery.ui.components.NovelActionSheet
 import com.emptycastle.novery.ui.components.NovelCard
 import com.emptycastle.novery.ui.components.NovelGridSkeleton
@@ -236,6 +237,19 @@ fun ProviderBrowseScreen(
             onAddToLibrary = { viewModel.addToLibrary(data.novel) }.takeIf { !data.isInLibrary },
             onRemoveFromLibrary = { viewModel.removeFromLibrary(data.novel.url) }.takeIf { data.isInLibrary },
             onRemoveFromHistory = null
+        )
+    }
+
+    actionSheetState.duplicateWarning?.let { warning ->
+        DuplicateLibraryDialog(
+            target = warning.target,
+            duplicates = warning.duplicates,
+            onViewExisting = { duplicate ->
+                viewModel.dismissDuplicateWarning()
+                onNavigateToDetails(duplicate.novel.url, duplicate.novel.apiName)
+            },
+            onAddAnyway = { viewModel.addDuplicateAnyway() },
+            onDismiss = { viewModel.dismissDuplicateWarning() }
         )
     }
 

--- a/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/ProviderBrowseViewModel.kt
+++ b/app/src/main/java/com/emptycastle/novery/ui/screens/home/tabs/browse/ProviderBrowseViewModel.kt
@@ -476,6 +476,14 @@ class ProviderBrowseViewModel(
         viewModelScope.launch { actionSheetManager.addToLibrary(novel) }
     }
 
+    fun addDuplicateAnyway() {
+        viewModelScope.launch { actionSheetManager.addDuplicateAnyway() }
+    }
+
+    fun dismissDuplicateWarning() {
+        actionSheetManager.dismissDuplicateWarning()
+    }
+
     fun removeFromLibrary(novelUrl: String) {
         viewModelScope.launch { actionSheetManager.removeFromLibrary(novelUrl) }
     }


### PR DESCRIPTION
Added duplicate protection when adding novels to the library.

If a user tries to add a novel that appears to already exist in their library, a bottom-sheet warning appears before adding it. This helps prevent accidental duplicate library entries when the same title is available from multiple sources.

## How It Works

When adding a novel, Novery compares the new title with existing library titles using a normalized title match. This ignores small differences, such as punctuation or bracketed suffixes, so similar entries are easier to catch.

If a possible duplicate is found, the user can:

 - Open the saved library entry
 - Add the new source anyway
 - Cancel
 
  _Notes: This does not automatically migrate reading progress between sources. It only warns about duplicates._
  
## Testing
  - Installed and tested on a physical Android device
  - Verified the duplicate warning bottom sheet works during real app testing

## Sneakpeak

<img width="720" height="1600" alt="Screenshot_20260501-092453" src="https://github.com/user-attachments/assets/fbadd423-26c9-4abe-b6fc-97f05e61e3e6" />
